### PR TITLE
[FEAT] Glimmer System 

### DIFF
--- a/Content.Server/_DEN/Glimmer/Commands/GlimmerCommand.cs
+++ b/Content.Server/_DEN/Glimmer/Commands/GlimmerCommand.cs
@@ -1,0 +1,115 @@
+using Content.Server._DEN.Glimmer.EntitySystems;
+using Content.Server.Administration;
+using Content.Shared._DEN.Glimmer.Components;
+using Content.Shared.Administration;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server._DEN.Glimmer.Commands;
+
+[ToolshedCommand, AdminCommand(AdminFlags.VarEdit)]
+public sealed partial class GlimmerCommand : ToolshedCommand
+{
+    private GlimmerTrackerSystem? _glimmerTracker;
+
+    [CommandImplementation("getTracker")]
+    public Entity<GlimmerTrackerComponent>? GetTracker([PipedArgument] EntityUid @target)
+    {
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+
+        if (_glimmerTracker.TryGetClosestGlimmerTracker(@target, out var tracker))
+            return tracker;
+
+        return null;
+    }
+
+    [CommandImplementation("getTracker")]
+    public Entity<GlimmerTrackerComponent>? GetTracker(IInvocationContext ctx)
+    {
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+
+        if (ctx.Session?.AttachedEntity is not { } entity)
+            return null;
+
+        if (_glimmerTracker.TryGetClosestGlimmerTracker(entity, out var tracker))
+            return tracker;
+
+        return null;
+    }
+
+    [CommandImplementation("getValue")]
+    public FixedPoint2? GetValue([PipedArgument] Entity<GlimmerTrackerComponent> @tracker)
+    {
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+        return _glimmerTracker.GetCurrentGlimmer(@tracker);
+    }
+
+    [CommandImplementation("getValue")]
+    public FixedPoint2? GetValue([PipedArgument] Entity<GlimmerTrackerComponent>? @tracker)
+    {
+        if (@tracker == null)
+            return FixedPoint2.Zero;
+
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+        return _glimmerTracker.GetCurrentGlimmer(@tracker.Value);
+    }
+
+    [CommandImplementation("getLevel")]
+    public int? GetLevel([PipedArgument] Entity<GlimmerTrackerComponent> @tracker)
+    {
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+        return _glimmerTracker.GetCurrentGlimmerLevel(@tracker);
+    }
+
+    [CommandImplementation("getLevel")]
+    public int? GetLevel([PipedArgument] Entity<GlimmerTrackerComponent>? @tracker)
+    {
+        if (@tracker == null)
+            return 0;
+
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+        return _glimmerTracker.GetCurrentGlimmerLevel(@tracker.Value);
+    }
+
+    [CommandImplementation("setValue")]
+    public Entity<GlimmerTrackerComponent> SetValue([PipedArgument] Entity<GlimmerTrackerComponent> @tracker, FixedPoint2 value)
+    {
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+        _glimmerTracker.SetGlimmer(@tracker, value);
+
+        return @tracker;
+    }
+
+    [CommandImplementation("setValue")]
+    public Entity<GlimmerTrackerComponent>? SetValue([PipedArgument] Entity<GlimmerTrackerComponent>? @tracker, FixedPoint2 value)
+    {
+        if (@tracker == null)
+            return @tracker;
+
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+        _glimmerTracker.SetGlimmer(@tracker.Value, value);
+
+        return @tracker;
+    }
+
+    [CommandImplementation("setLevel")]
+    public Entity<GlimmerTrackerComponent> SetLevel([PipedArgument] Entity<GlimmerTrackerComponent> @tracker, int level)
+    {
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+        _glimmerTracker.SetGlimmerLevel(@tracker, level);
+
+        return @tracker;
+    }
+
+    [CommandImplementation("setLevel")]
+    public Entity<GlimmerTrackerComponent>? SetLevel([PipedArgument] Entity<GlimmerTrackerComponent>? @tracker, int level)
+    {
+        if (@tracker == null)
+            return @tracker;
+
+        _glimmerTracker ??= GetSys<GlimmerTrackerSystem>();
+        _glimmerTracker.SetGlimmerLevel(@tracker.Value, level);
+
+        return @tracker;
+    }
+}

--- a/Content.Server/_DEN/Glimmer/EntitySystems/GlimmerSystem.cs
+++ b/Content.Server/_DEN/Glimmer/EntitySystems/GlimmerSystem.cs
@@ -50,7 +50,8 @@ public sealed partial class GlimmerTrackerSystem : SharedGlimmerTrackerSystem
     /// <param name="uid">The entity to retrieve the nearest valid glimmer tracker for.</param>
     /// <param name="trackerEnt">A glimmer tracker that applies to this entity.</param>
     /// <returns>Whether or not we successfully retrieved a glimmer tracker.</returns>
-    private bool TryGetClosestGlimmerTracker(EntityUid uid,
+    [PublicAPI]
+    public bool TryGetClosestGlimmerTracker(EntityUid uid,
         [NotNullWhen(true)] out Entity<GlimmerTrackerComponent>? trackerEnt)
     {
         // This entity is a glimmer tracker
@@ -96,9 +97,15 @@ public sealed partial class GlimmerTrackerSystem : SharedGlimmerTrackerSystem
     /// </summary>
     /// <param name="tracker"></param>
     /// <param name="glimmer"></param>
-    private void SetGlimmer(Entity<GlimmerTrackerComponent> tracker, FixedPoint2 glimmer)
+    [PublicAPI]
+    public void SetGlimmer(Entity<GlimmerTrackerComponent> tracker, FixedPoint2 glimmer)
     {
         var comp = tracker.Comp;
+        var maxGlimmer = comp.GlimmerLevels * comp.GlimmerPerLevel;
+
+        if (glimmer < FixedPoint2.Zero || glimmer > maxGlimmer)
+            throw new ArgumentOutOfRangeException(nameof(glimmer));
+
         comp.CurrentGlimmer = glimmer;
 
         // We're adding 1 to this, so that 0 glimmer becomes level 1.
@@ -112,10 +119,22 @@ public sealed partial class GlimmerTrackerSystem : SharedGlimmerTrackerSystem
     /// </summary>
     /// <param name="tracker"></param>
     /// <param name="level"></param>
-    private void SetGlimmerLevel(Entity<GlimmerTrackerComponent> tracker, int level)
+    [PublicAPI]
+    public void SetGlimmerLevel(Entity<GlimmerTrackerComponent> tracker, int level)
     {
         var comp = tracker.Comp;
+
+        if (level < 0 || level > comp.GlimmerLevels)
+            throw new ArgumentOutOfRangeException(nameof(level));
+
         comp.CurrentGlimmerLevel = level;
+
+        // The highest glimmer level always represents the highest possible glimmer value.
+        if (level == comp.GlimmerLevels)
+        {
+            comp.CurrentGlimmer = level * comp.GlimmerPerLevel;
+            return;
+        }
 
         var min = (level - 1) * comp.GlimmerPerLevel; // INCLUSIVE
         var max = level * comp.GlimmerPerLevel; // EXCLUSIVE

--- a/Content.Server/_DEN/Glimmer/EntitySystems/GlimmerSystem.cs
+++ b/Content.Server/_DEN/Glimmer/EntitySystems/GlimmerSystem.cs
@@ -1,0 +1,175 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Server.Station.Systems;
+using Content.Shared._DEN.Glimmer.Components;
+using Content.Shared._DEN.Glimmer.EntitySystems;
+using Content.Shared.FixedPoint;
+using JetBrains.Annotations;
+using Robust.Shared.Random;
+
+namespace Content.Server._DEN.Glimmer.EntitySystems;
+
+/// <summary>
+///     Glimmer is a measure of "noospheric instability", a value that affects both the frequency
+///     and severity of paranormal-themed events. It also affects the level of connection that
+///     psionic users have with the noosphere - this is to say, powers scaling with glimmer.
+/// </summary>
+public sealed partial class GlimmerTrackerSystem : SharedGlimmerTrackerSystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GlimmerTrackerComponent, ComponentStartup>(OnGlimmerTrackerStartup);
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="ent"></param>
+    /// <param name="args"></param>
+    private void OnGlimmerTrackerStartup(Entity<GlimmerTrackerComponent> ent, ref ComponentStartup args)
+    {
+        var comp = ent.Comp;
+        var min = comp.StartingGlimmerLevelRange.X;
+        var max = comp.StartingGlimmerLevelRange.Y;
+        var level = _random.Next(min, max);
+
+        SetGlimmerLevel(ent, level);
+    }
+
+    /// <summary>
+    ///     Attempt to get the closest applicable glimmer tracker for a given entity.
+    /// </summary>
+    /// <remarks>
+    ///     The entity itself will be checked if it is a glimmer tracker, then the entity's station,
+    ///     then all trackers will be iterated over to find the closest applicable tracker.
+    /// </remarks>
+    /// <param name="uid">The entity to retrieve the nearest valid glimmer tracker for.</param>
+    /// <param name="trackerEnt">A glimmer tracker that applies to this entity.</param>
+    /// <returns>Whether or not we successfully retrieved a glimmer tracker.</returns>
+    private bool TryGetClosestGlimmerTracker(EntityUid uid,
+        [NotNullWhen(true)] out Entity<GlimmerTrackerComponent>? trackerEnt)
+    {
+        // This entity is a glimmer tracker
+        if (TryComp<GlimmerTrackerComponent>(uid, out var tracker))
+        {
+            trackerEnt = (uid, tracker);
+            return true;
+        }
+
+        // This is a station map and the station has a glimmer tracker
+        var xform = Transform(uid);
+        if (_station.GetStationInMap(xform.MapID) is EntityUid station
+            && TryComp(station, out tracker))
+        {
+            trackerEnt = (station, tracker);
+            return true;
+        }
+
+        // We get the closest glimmer tracker in the same map
+        var query = EntityQueryEnumerator<GlimmerTrackerComponent>();
+        (Entity<GlimmerTrackerComponent> Tracker, float Distance)? closestTracker = null;
+        while (query.MoveNext(out var trackerUid, out tracker))
+        {
+            var ent = (trackerUid, tracker);
+            var trackerXform = Transform(trackerUid);
+
+            if (xform.Coordinates.TryDistance(EntityManager, trackerXform.Coordinates, out var distance)
+                && distance > closestTracker?.Distance)
+                closestTracker = (ent, distance);
+
+            // Global trackers do not need to be in the same map to be detected
+            else if (tracker.Global)
+                closestTracker ??= (ent, float.MaxValue);
+        }
+
+        // May still be null, if there are no trackers at all
+        trackerEnt = closestTracker?.Tracker;
+        return trackerEnt != null;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="tracker"></param>
+    /// <param name="glimmer"></param>
+    private void SetGlimmer(Entity<GlimmerTrackerComponent> tracker, FixedPoint2 glimmer)
+    {
+        var comp = tracker.Comp;
+        comp.CurrentGlimmer = glimmer;
+
+        // We're adding 1 to this, so that 0 glimmer becomes level 1.
+        var glimmerDivisor = (glimmer + 1) / comp.GlimmerPerLevel;
+        var glimmerLevel = Math.Floor(glimmerDivisor.Float());
+        comp.CurrentGlimmerLevel = (int)glimmerLevel;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="tracker"></param>
+    /// <param name="level"></param>
+    private void SetGlimmerLevel(Entity<GlimmerTrackerComponent> tracker, int level)
+    {
+        var comp = tracker.Comp;
+        comp.CurrentGlimmerLevel = level;
+
+        var min = (level - 1) * comp.GlimmerPerLevel; // INCLUSIVE
+        var max = level * comp.GlimmerPerLevel; // EXCLUSIVE
+        var newGlimmer = _random.NextFloat(min.Float(), max.Float());
+        comp.CurrentGlimmer = FixedPoint2.New(newGlimmer);
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="tracker"></param>
+    /// <returns></returns>
+    [PublicAPI]
+    public FixedPoint2 GetCurrentGlimmer(Entity<GlimmerTrackerComponent> tracker)
+    {
+        return tracker.Comp.CurrentGlimmer;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <returns></returns>
+    [PublicAPI]
+    public FixedPoint2 GetCurrentGlimmer(EntityUid uid)
+    {
+        if (!TryGetClosestGlimmerTracker(uid, out var tracker))
+            return FixedPoint2.Zero;
+
+        return GetCurrentGlimmer(tracker.Value);
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="tracker"></param>
+    /// <returns></returns>
+    [PublicAPI]
+    public int GetCurrentGlimmerLevel(Entity<GlimmerTrackerComponent> tracker)
+    {
+        return tracker.Comp.CurrentGlimmerLevel;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <returns></returns>
+    [PublicAPI]
+    public int GetCurrentGlimmerLevel(EntityUid uid)
+    {
+        if (!TryGetClosestGlimmerTracker(uid, out var tracker))
+            return 0;
+
+        return GetCurrentGlimmerLevel(tracker.Value);
+    }
+}

--- a/Content.Shared/_DEN/Glimmer/Components/GlimmerTrackerComponent.cs
+++ b/Content.Shared/_DEN/Glimmer/Components/GlimmerTrackerComponent.cs
@@ -1,0 +1,93 @@
+using Content.Shared._DEN.Glimmer.EntitySystems;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared._DEN.Glimmer.Components;
+
+/// <summary>
+///     A tracker component for measuring glimmer, a measure of current noospheric
+///     instability and influence. Glimmer naturally shifts and fluctuates over time, but
+///     player interference may cause it to shift one way or the other.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(SharedGlimmerTrackerSystem))]
+public sealed partial class GlimmerTrackerComponent : Component
+{
+    /// <summary>
+    ///     How many levels of glimmer should we have?
+    /// </summary>
+    [DataField]
+    public int GlimmerLevels = 10;
+
+    /// <summary>
+    ///     How many points of glimmer are in a glimmer level threshold?
+    /// </summary>
+    [DataField]
+    public FixedPoint2 GlimmerPerLevel = 100.0f;
+
+    /// <summary>
+    ///     What level of glimmer should we start with?
+    /// </summary>
+    [DataField]
+    public Vector2i StartingGlimmerLevelRange = new(1, 1);
+
+    /// <summary>
+    ///     An optional limit to what range of glimmer levels we can have.
+    /// </summary>
+    /// <remarks>
+    ///     This is meaningful because if GLs runs from 0 to 10, then capping GLs
+    ///     between, say, 4 to 7, would ensure constant "moderate-to-high glimmer".
+    /// </remarks>
+    [DataField]
+    public Vector2i? PossibleGlimmerLevelRange = null;
+
+    /// <summary>
+    ///     Whether or not glimmer can be changed via gameplay means - random
+    ///     fluctuation, events, and player interference.
+    /// </summary>
+    /// <remarks>
+    ///     Admins are always capable of changing the current level or amount of glimmer.
+    /// </remarks>
+    [DataField]
+    public bool AllowGlimmerChange = true;
+
+    /// <summary>
+    ///     Whether or not this tracker can be used by other maps.
+    /// </summary>
+    [DataField]
+    public bool Global = false;
+
+    /// <summary>
+    ///     Whether or not actions that happen off the map this entity is contained in
+    ///     can affect this glimmer tracker.
+    /// </summary>
+    /// <remarks>
+    ///     For example: if this is disabled, then psionics usage at CentComm will not
+    ///     affect the station glimmer tracker.
+    /// </remarks>
+    [DataField]
+    public bool OffMapAffectsGlimmer = false;
+
+    /// <summary>
+    ///     How much glimmer do we currently have?
+    /// </summary>
+    /// <remarks>
+    ///     Note that setting glimmer directly is not super meaningful or long-term;
+    ///     glimmer frequently fluctuates.
+    /// </remarks>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public FixedPoint2 CurrentGlimmer = 0;
+
+    /// <summary>
+    ///     What is our current glimmer level?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public int CurrentGlimmerLevel = 1;
+
+    /// <remarks>
+    ///     Glimmer is represented as a range from 0 to (GlimmerLevels * GlimmerPerLevel).
+    ///     Assuming there are 10 levels with 100 glimmer each: [0-100) glimmer is level 1,
+    ///     [100-200) glimmer is level 2, et cetera. 1000 glimmer is level 10.
+    /// </remarks>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public FixedPoint2 MaxGlimmer => GlimmerPerLevel * GlimmerLevels;
+}

--- a/Content.Shared/_DEN/Glimmer/Components/GlimmerTrackerComponent.cs
+++ b/Content.Shared/_DEN/Glimmer/Components/GlimmerTrackerComponent.cs
@@ -28,7 +28,7 @@ public sealed partial class GlimmerTrackerComponent : Component
     ///     What level of glimmer should we start with?
     /// </summary>
     [DataField]
-    public Vector2i StartingGlimmerLevelRange = new(1, 1);
+    public Vector2i StartingGlimmerLevelRange = new(0, 2);
 
     /// <summary>
     ///     An optional limit to what range of glimmer levels we can have.
@@ -81,7 +81,7 @@ public sealed partial class GlimmerTrackerComponent : Component
     ///     What is our current glimmer level?
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
-    public int CurrentGlimmerLevel = 1;
+    public int CurrentGlimmerLevel = 0;
 
     /// <remarks>
     ///     Glimmer is represented as a range from 0 to (GlimmerLevels * GlimmerPerLevel).

--- a/Content.Shared/_DEN/Glimmer/EntitySystems/SharedGlimmerSystem.cs
+++ b/Content.Shared/_DEN/Glimmer/EntitySystems/SharedGlimmerSystem.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._DEN.Glimmer.EntitySystems;
+
+public abstract partial class SharedGlimmerTrackerSystem : EntitySystem
+{ }

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -27,6 +27,7 @@
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
     - BaseStationDeliveries
+    - BaseStationGlimmer # DEN: Glimmer tracking
   categories: [ HideSpawnMenu ]
   components:
     - type: Transform

--- a/Resources/Prototypes/_DEN/Stations/base.yml
+++ b/Resources/Prototypes/_DEN/Stations/base.yml
@@ -5,6 +5,6 @@
   - type: GlimmerTracker
     glimmerLevels: 10
     glimmerPerLevel: 100
-    startingGlimmerLevelRange: 1, 1
+    startingGlimmerLevelRange: 0, 2
     global: true
     offMapAffectsGlimmer: true

--- a/Resources/Prototypes/_DEN/Stations/base.yml
+++ b/Resources/Prototypes/_DEN/Stations/base.yml
@@ -1,0 +1,10 @@
+- type: entity
+  abstract: true
+  id: BaseStationGlimmer
+  components:
+  - type: GlimmerTracker
+    glimmerLevels: 10
+    glimmerPerLevel: 100
+    startingGlimmerLevelRange: 1, 1
+    global: true
+    offMapAffectsGlimmer: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
- #20 

This is part 1 of the Epistemics redesign: the implementation of the Glimmer tracker, which (currently) will be the Big Number that our epistemics mechanics will revolve around.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Gotta start somewhere.

## Technical details
<!-- Summary of code changes for easier review. -->
TBA

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
TBA

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Macrocosm [Pull Request Conventions ](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [ ] I have added media to this PR or it does not require an in-game showcase.
- [ ] I have tested my changes and additions in-game.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

### Licensing
<!--
    This is REQUIRED for any code submitted to The Den 2 repository.
    If this is a port, make sure to check the original repository's license!

    This code can be licensed to MIT if:
    1. You wrote it yourself, and you agree it can be MIT-licensed.
    2. The original pull request originates from an MIT-licensed codebase, such as Wizard's Den.
    3. The original code author submitted the code to a non-MIT (e.g. AGPLv3) codebase, but
       has given explicit permission to have their code re-licensed.

    If your code does not fit these cases, it probably can't be accepted!
    If you need help getting MIT licensing, please ask for help in our development channels.
-->
- [x] All code in this pull request can be licensed to MIT.

<!--
    Macrocosm is The Den 2's upstream repository. We may port features to Macrocosm if other
    servers that share the Macrocosm upstream are interested in the feature.
-->
- [ ] (OPTIONAL) I give permission to seeing this feature upstreamed to Macrocosm in the future.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

**Changelog**
:cl:
- add: The Glimmer tracker has been implemented. Glimmer is a numerical measurement from 0 to 1000 of current noospheric instability, and in the future it will be used to affect psionically-sensitive characters and cause paranormal events.