### PR TITLE
Special Protection Part 1 - Marker Component and Entities

### DIFF
--- a/Content.Shared/_DEN/SpecialProtection/Components/SpecialProtectionComponent.cs
+++ b/Content.Shared/_DEN/SpecialProtection/Components/SpecialProtectionComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared._DEN.SpecialProtection.Components;
+
+/// <summary>
+/// This component marks an entity as specially protected - used for not spawning critters on dorm vents, not turning off APCs etc etc.
+/// </summary>
+
+[RegisterComponent]
+public sealed partial class SpecialProtectionComponent : Component { }

--- a/Resources/Prototypes/_DEN/SpecialProtection/base.yml
+++ b/Resources/Prototypes/_DEN/SpecialProtection/base.yml
@@ -1,0 +1,6 @@
+- type: entity
+  id: BaseSpecialProtection
+  abstract: true
+  suffix: Special Protection
+  components:
+    - type: SpecialProtection

--- a/Resources/Prototypes/_DEN/SpecialProtection/entities.yml
+++ b/Resources/Prototypes/_DEN/SpecialProtection/entities.yml
@@ -1,0 +1,42 @@
+# Electrical devices
+
+- type: entity
+  parent: [ BaseAPC, BaseSpecialProtection ]
+  id: APCSpecialProtection
+
+
+# Atmos devices
+
+- type: entity
+  parent: [ GasVentScrubber, BaseSpecialProtection ]
+  id: GasVentScrubberSpecialProtection
+
+- type: entity
+  parent: [ GasVentPump, BaseSpecialProtection ]
+  id: GasVentPumpSpecialProtection
+
+
+# Doors
+
+- type: entity
+  parent: [ Airlock, BaseSpecialProtection ]
+  id: AirlockSpecialProtection
+
+
+# Buttons, switches
+
+- type: entity
+  parent: [ SignalSwitch, BaseSpecialProtection ]
+  id: SignalSwitchSpecialProtection
+
+- type: entity
+  parent: [ SignalButton, BaseSpecialProtection ]
+  id: SignalButtonSpecialProtection
+
+- type: entity
+  parent: [ SignalSwitchDirectional, BaseSpecialProtection ]
+  id: SignalSwitchDirectionalSpecialProtection
+
+- type: entity
+  parent: [ SignalButtonDirectional, BaseSpecialProtection ]
+  id: SignalButtonDirectionalSpecialProtection


### PR DESCRIPTION
## About the PR
Added a bunch of entities with the new SpecialProtectionComponent.
No player facing changes so no changelog. This is for mappers and event organisers only.
Actually making systems check for this component and adjust logic based on its presence will be another PR.

## Why / Balance
We need specially marked entities to use near protected areas in order to avoid a situation where a RP scene is broken up by a random event.

## Technical details
Added a new SpecialProtectionComponent, and created a parent that has this component. Made all the special prototypes inherit from that base parent for future customizability.

## Requirements
- [x] I have read and am following the Macrocosm [Pull Request Conventions ](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] I have tested my changes and additions in-game.

### Licensing
- [x] All code in this pull request can be licensed to MIT.
- [x] (OPTIONAL) I give permission to seeing this feature upstreamed to Macrocosm in the future.
