### PR TITLE
Loadout Modules

### DIFF
--- a/Content.Server/_DEN/Loadout/Modules/ColorableModule.cs
+++ b/Content.Server/_DEN/Loadout/Modules/ColorableModule.cs
@@ -1,0 +1,25 @@
+using Content.Shared._DEN.Recolor;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DEN.Loadout.Modules;
+
+public sealed class ColorableModule : ILoadoutModule
+{
+    /// <summary>
+    /// The hex color to tint the item.
+    /// </summary>
+    public required string ColorTint {  get; set; }
+
+    public void OnEntitySpawn(IEntityManager entMan,
+        IPrototypeManager protoMan,
+        EntityUid uid)
+    {
+        var recolorSystem = entMan.System<RecolorSystem>();
+        var hexColor = Color.TryFromHex(ColorTint);
+
+        if (hexColor is null)
+            return;
+
+        recolorSystem.Recolor(uid, hexColor.Value, false);
+    }
+}

--- a/Content.Server/_DEN/Loadout/Modules/ColorableModule.cs
+++ b/Content.Server/_DEN/Loadout/Modules/ColorableModule.cs
@@ -3,6 +3,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server._DEN.Loadout.Modules;
 
+[Serializable]
 public sealed class ColorableModule : ILoadoutModule
 {
     /// <summary>

--- a/Content.Server/_DEN/Loadout/Modules/DescribableModule.cs
+++ b/Content.Server/_DEN/Loadout/Modules/DescribableModule.cs
@@ -1,0 +1,36 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DEN.Loadout.Modules;
+
+[Serializable]
+public sealed class DescribableModule : ILoadoutModule
+{
+    /// <summary>
+    /// The name of the item as per examine.
+    /// </summary>
+    public string? CustomName { get; set; }
+
+    /// <summary>
+    /// The description of the item as per examine.
+    /// </summary>
+    public string? CustomDescription { get; set; }
+
+    public void OnEntitySpawn(IEntityManager entMan,
+        IPrototypeManager protoMan,
+        EntityUid uid)
+    {
+        if (!entMan.TryGetComponent<MetaDataComponent>(uid, out var metaData))
+            return;
+
+        if (string.IsNullOrWhiteSpace(CustomName) && string.IsNullOrWhiteSpace(CustomDescription))
+            return;
+
+        var metaDataSystem = entMan.System<MetaDataSystem>();
+
+        if (!string.IsNullOrEmpty(CustomName))
+            metaDataSystem.SetEntityName(uid, CustomName, metaData);
+
+        if (!string.IsNullOrEmpty(CustomDescription))
+            metaDataSystem.SetEntityDescription(uid, CustomDescription, metaData);
+    }
+}

--- a/Content.Server/_DEN/Loadout/Modules/ILoadoutModule.cs
+++ b/Content.Server/_DEN/Loadout/Modules/ILoadoutModule.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DEN.Loadout.Modules;
+
+public interface ILoadoutModule
+{
+    void OnEntitySpawn(IEntityManager entMan,
+        IPrototypeManager protoMan,
+        EntityUid uid);
+}
+

--- a/Content.Shared/_DEN/Recolor/RecolorSystem.cs
+++ b/Content.Shared/_DEN/Recolor/RecolorSystem.cs
@@ -100,8 +100,8 @@ public sealed partial class RecolorSystem : EntitySystem
         EntityUid uid,
         Color color,
         bool removable,
-        string? shader,
-        string? paintType,
+        string? shader = null,
+        string? paintType = null,
         EntityUid? recolorer = null)
     {
         var recolorData = new RecolorData


### PR DESCRIPTION
changes recolorsystem Recolor method to use null for shader and paint type by default
adds an interface for use in the future mega loadout update (when we get around to discussing loadout UI)