### PR TITLE
[Feature] Language event and proper tag handling

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Server.Chat.Managers;
@@ -188,6 +189,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         // Capitalizing the word I only happens in English, so we check language here
         bool shouldCapitalizeTheWordI = (!CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Parent.Name == "en")
             || (CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Name == "en");
+        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldPunctuate, shouldCapitalizeTheWordI);
 
         // DEN: Detailed message system.
         bool needsRadio = false;
@@ -201,21 +203,20 @@ public sealed partial class ChatSystem : SharedChatSystem
                 message = modMessage;
             }
         }
+        
         var complexMessage = ConvertMessageToComplex(message);
-        complexMessage = SanitizeComplexMessage(source, complexMessage, out var emoteStrs, shouldCapitalize, shouldPunctuate, shouldCapitalizeTheWordI);
-
-        // DEN: Send emote strings extracted from the complex message.
-        // Multiple emotes in multiple dialogs works. I hope no one ever actually does this.
-        if (player != null && emoteStrs.Count != 0)
+        
+        if (player != null 
+            && emoteStr != message
+            && emoteStr != null
+            && desiredType is not InGameICChatType.Subtle)
         {
-            foreach (var emoteStr in emoteStrs)
-            {
-                SendEntityEmote(source, emoteStr, range, nameOverride, ignoreActionBlocker);
-            }
+            SendEntityEmote(source, emoteStr, range, nameOverride, ignoreActionBlocker);
         }
 
-        // DEN: Complex message will be empty, rather than a null string.
-        if (complexMessage.Parts.Count == 0)
+        // DEN: Complex message will be empty, rather than a null string. Also eat any message that is only tags.
+        if (complexMessage.Parts.Count == 0 
+            || complexMessage.Parts.All(part => part.Item1 is ChatPart.EmoteTag or ChatPart.DialogTag))
             return;
 
         // DEN: Complex message parsing.

--- a/Content.Server/_DEN/Chat/Systems/ChatSystem.Language.cs
+++ b/Content.Server/_DEN/Chat/Systems/ChatSystem.Language.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using System.Text;
 using Content.Server._DEN.Language.EntitySystems;
+using Content.Server._DEN.Language.Events;
 using Content.Shared._DEN.Language;
 using Content.Shared._DEN.Language.Components;
 using Content.Shared._DEN.Language.EntitySystems;
@@ -164,6 +166,9 @@ public sealed partial class ChatSystem
 
         var ev = new EntitySpokeEvent(source, languageEnt, message, radioChannel, verb, chatChannel);
         RaiseLocalEvent(source, ev, true);
+
+        var evt = new LanguageSpokenWithEvent(source, message, radioChannel, chatChannel);
+        RaiseLocalEvent(languageEnt, evt);
 
         // The message wasn't sent by a player, so don't log it. Prevents radios and cameras from causing a player's
         // message to be logged many times.
@@ -379,9 +384,45 @@ public sealed partial class ChatSystem
         }
         else
         {
+            // Combine tags back into emotes and dialog so they can be formatted.
+            List<(ChatPart, string)> mergedParts = [];
+            var workingSet = message.Parts;
+            Log.Debug("What: " + workingSet);
+            var lastSeen = workingSet[0];
+            for (int i = 0; i < workingSet.Count; i++)
+            {
+                if (i == 0)
+                {
+                    lastSeen = workingSet[0];
+                    continue;
+                }
+
+                var current = workingSet[i];
+                // Matching Dialog or Emote.
+                if ((lastSeen.Item1 is ChatPart.Dialog or ChatPart.DialogTag 
+                    && current.Item1 is ChatPart.Dialog or ChatPart.DialogTag) 
+                    || (lastSeen.Item1 is ChatPart.Emote or ChatPart.EmoteTag
+                        && current.Item1 is ChatPart.Emote or ChatPart.EmoteTag))
+                {
+                    lastSeen.Item2 += current.Item2;
+                    
+                    if (lastSeen.Item1 is ChatPart.DialogTag)
+                        lastSeen.Item1 = ChatPart.Dialog;
+                    if (lastSeen.Item1 is ChatPart.EmoteTag)
+                        lastSeen.Item1 = ChatPart.Emote;
+                }
+                // This means that they are different.
+                else
+                {
+                    mergedParts.Add(lastSeen);
+                    lastSeen = current;
+                }
+            }
+            mergedParts.Add(lastSeen);
+            
             // Loop over the parts of the complex speech.
             // Dialog gets a lot of special formatting where as emotes just get default action formatting.
-            foreach (var (kind, part) in message.Parts)
+            foreach (var (kind, part) in mergedParts)
             {
                 if (kind == ChatPart.Dialog)
                 {
@@ -497,39 +538,5 @@ public sealed partial class ChatSystem
         RaiseLocalEvent(sender, transformEvt, true);
 
         return transformEvt.Message;
-    }
-
-    // Runs sanitation but only on the dialog parts of the message.
-    private ComplexChatMessage SanitizeComplexMessage(EntityUid source,
-        ComplexChatMessage message,
-        out List<string> emoteStrs,
-        bool shouldCapitalize = true,
-        bool punctuate = false,
-        bool capitalizeTheWordI = true)
-    {
-        emoteStrs = [];
-        var newParts = new List<(ChatPart, string)>(message.Parts.Count);
-        foreach (var part in message.Parts)
-        {
-            if (part.Item1 == ChatPart.Dialog)
-            {
-                var sanitized = SanitizeInGameICMessage(source,
-                    part.Item2,
-                    out var emote,
-                    shouldCapitalize,
-                    punctuate,
-                    capitalizeTheWordI);
-                if (!string.IsNullOrEmpty(sanitized))
-                    newParts.Add((part.Item1, sanitized));
-                if (emote is not null)
-                    emoteStrs.Add(emote);
-            }
-            else
-            {
-                newParts.Add((part.Item1, part.Item2));
-            }
-        }
-
-        return new ComplexChatMessage(message, newParts);
     }
 }

--- a/Content.Server/_DEN/Chat/Systems/ChatSystem.Language.cs
+++ b/Content.Server/_DEN/Chat/Systems/ChatSystem.Language.cs
@@ -387,7 +387,6 @@ public sealed partial class ChatSystem
             // Combine tags back into emotes and dialog so they can be formatted.
             List<(ChatPart, string)> mergedParts = [];
             var workingSet = message.Parts;
-            Log.Debug("What: " + workingSet);
             var lastSeen = workingSet[0];
             for (int i = 0; i < workingSet.Count; i++)
             {
@@ -405,15 +404,14 @@ public sealed partial class ChatSystem
                         && current.Item1 is ChatPart.Emote or ChatPart.EmoteTag))
                 {
                     lastSeen.Item2 += current.Item2;
-                    
-                    if (lastSeen.Item1 is ChatPart.DialogTag)
-                        lastSeen.Item1 = ChatPart.Dialog;
-                    if (lastSeen.Item1 is ChatPart.EmoteTag)
-                        lastSeen.Item1 = ChatPart.Emote;
                 }
                 // This means that they are different.
                 else
                 {
+                    if (lastSeen.Item1 == ChatPart.DialogTag)
+                        lastSeen.Item1 = ChatPart.Dialog;
+                    else if (lastSeen.Item1 == ChatPart.EmoteTag)
+                        lastSeen.Item1 = ChatPart.Emote;
                     mergedParts.Add(lastSeen);
                     lastSeen = current;
                 }

--- a/Content.Server/_DEN/Language/Events/LanguageEvents.cs
+++ b/Content.Server/_DEN/Language/Events/LanguageEvents.cs
@@ -1,0 +1,46 @@
+using Content.Shared.Chat;
+using Content.Shared.Radio;
+
+namespace Content.Server._DEN.Language.Events;
+
+/// <summary>
+/// Raised on a language entity when it is used to speak.
+/// </summary>
+public sealed class LanguageSpokenWithEvent : EntityEventArgs
+{
+    /// <summary>
+    /// The Entity doing the speaking.
+    /// </summary>
+    public readonly EntityUid Source;
+    
+    /// <summary>
+    /// The message that was spoken.
+    /// </summary>
+    public readonly ComplexChatMessage Message;
+    
+    /// <summary>
+    /// The chat channel spoken in.
+    /// </summary>
+    public readonly ChatChannel ChatChannel;
+    
+    /// <summary>
+    /// The radio channel spoken in, if any.
+    /// </summary>
+    public readonly RadioChannelPrototype? Channel;
+
+    /// <summary>
+    /// Event called on a language entity when it is used to speak.
+    /// </summary>
+    /// <param name="source">The Entity doing the speaking.</param>
+    /// <param name="message">The message that was spoken.</param>
+    /// <param name="channel">The chat channel spoken in.</param>
+    /// <param name="chatChannel">The radio channel spoken in, if any.</param>
+    public LanguageSpokenWithEvent(EntityUid source, ComplexChatMessage message, RadioChannelPrototype? channel,
+        ChatChannel chatChannel)
+    {
+        Source = source;
+        Message = message;
+        Channel = channel;
+        ChatChannel = chatChannel;
+    }
+}

--- a/Content.Shared/_DEN/Chat/SharedChatSystem.Language.cs
+++ b/Content.Shared/_DEN/Chat/SharedChatSystem.Language.cs
@@ -112,7 +112,8 @@ public enum ChatPart
 {
     Dialog,
     Emote,
-    Tag
+    DialogTag,
+    EmoteTag,
 }
 
 public readonly record struct ComplexChatMessage()
@@ -160,19 +161,35 @@ public readonly record struct ComplexChatMessage()
         NeedsSeparation = needsSeparation;
         if (escapeMarkup)
             message = FormattedMessage.EscapeText(message);
+
+        var parsedMsg = FormattedMessage.FromMarkupPermissive(message);
+        List<(ChatPart, string)> parts = [];
         if (!isDetailed)
         {
-            Parts = [(ChatPart.Dialog, message)];
+            foreach (var hunk in parsedMsg.Nodes)
+            {
+                parts.Add((hunk.IsPlainText ? ChatPart.Dialog : ChatPart.DialogTag, hunk.ToString()));
+            }
+
+            Parts = parts;
             return;
         }
 
         var outside = false;
-        List<(ChatPart, string)> parts = [];
-        foreach (var msgChunk in message.Split(delimiter))
+        foreach (var hunk in parsedMsg.Nodes)
         {
-            if (!string.IsNullOrEmpty(msgChunk))
-                parts.Add((outside ? ChatPart.Dialog : ChatPart.Emote, msgChunk));
-            outside = !outside;
+            if (!hunk.IsPlainText)
+            {
+                parts.Add((outside ? ChatPart.DialogTag : ChatPart.EmoteTag, hunk.ToString()));
+                continue;
+            }
+            
+            foreach (var msgChunk in hunk.ToString().Split(Delimiter))
+            {
+                if (!string.IsNullOrEmpty(msgChunk))
+                    parts.Add((outside ? ChatPart.Dialog : ChatPart.Emote, msgChunk));
+                outside = !outside;
+            }
         }
 
         Parts = parts;

--- a/Content.Shared/_DEN/Chat/SharedChatSystem.Language.cs
+++ b/Content.Shared/_DEN/Chat/SharedChatSystem.Language.cs
@@ -183,8 +183,16 @@ public readonly record struct ComplexChatMessage()
                 parts.Add((outside ? ChatPart.DialogTag : ChatPart.EmoteTag, hunk.ToString()));
                 continue;
             }
+
+            // Don't swap output between tags.
+            var pieces = hunk.ToString().Split(Delimiter);
+            if (pieces.Length == 1 && !string.IsNullOrEmpty(pieces[0]))
+            {
+                parts.Add((outside ? ChatPart.Dialog : ChatPart.Emote, pieces[0]));
+                continue;
+            }
             
-            foreach (var msgChunk in hunk.ToString().Split(Delimiter))
+            foreach (var msgChunk in pieces)
             {
                 if (!string.IsNullOrEmpty(msgChunk))
                     parts.Add((outside ? ChatPart.Dialog : ChatPart.Emote, msgChunk));


### PR DESCRIPTION
## About the PR
Made it so that languages correctly differentiates between tags and dialog and emotes.

Also adds an event to a language entity being used for use later.

## Why / Balance
Accents and bloodloss breaking formatting from hand typing or from Denu sucks.

## Technical details
Parse the message into tags, and then reconstruct it back into dialog after all of the accent and language formatting has been applied. DialogTag and EmoteTag are separate so that the system knows which side of quotes to put the tag on when rebuilding the message.

The formatter and the parser are evil and I'm sorry.

## Test plan
* Control a mod that speaks a language.
* Send some messages using tags.
* Remove all of your blood or otherwise apply an accent.
* Send more messages with tags and observe that they keep working.

## Media
<img width="490" height="207" alt="image" src="https://github.com/user-attachments/assets/b990ef68-5df0-4e9f-bf96-17d5b7d68f4c" />

## Requirements
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it.
- [X] I have added media to this PR or it does not require an in-game showcase.

### Licensing
- [X] All code in this pull request can be licensed to MIT.
- [X] (OPTIONAL) I give permission to seeing this feature upstreamed to Macrocosm in the future.

## Breaking changes

## Changelog
:cl:
- add: Accents and languages now respect formatting tags.
