### PR TITLE
Make whispers respect LOS and invisible to observers.

### DIFF
--- a/Content.Server/_DEN/Chat/Systems/ChatSystem.Language.cs
+++ b/Content.Server/_DEN/Chat/Systems/ChatSystem.Language.cs
@@ -112,7 +112,7 @@ public sealed partial class ChatSystem
         // TODO: It's still weird that this is hardcoded, but you can expand it anyway so it's not the end of the world.
         // Find all of the recipients in our provided range and send the message to them.
         foreach (var (session, data) in GetRecipients(source,
-                     chatChannel == ChatChannel.Whisper ? WhisperMuffledRange : VoiceRange))
+                     chatChannel == ChatChannel.Whisper ? WhisperClearRange : VoiceRange))
         {
             var entRange = MessageRangeCheck(session, data, range);
             if (entRange == MessageRangeCheckResult.Disallowed)
@@ -125,9 +125,15 @@ public sealed partial class ChatSystem
 
             var entHideChat = entRange == MessageRangeCheckResult.HideChat;
 
-            // Don't bother checking the event if the player doesn't have an entity.
+            // Don't bother checking the event if the player doesn't have an entity.s
             if (session.AttachedEntity is { Valid: true } playerEntity)
             {
+                // Hide whispers based on LOS and from ghosts.
+                if (chatChannel == ChatChannel.Whisper &&
+                    (!_interaction.InRangeUnobstructed(source, playerEntity, WhisperClearRange)
+                    || data.Observer))
+                    continue;
+                
                 SendComplexMessageToEntity(source,
                     playerEntity,
                     languageEnt,

--- a/Resources/Prototypes/_DEN/Language/base.yml
+++ b/Resources/Prototypes/_DEN/Language/base.yml
@@ -6,5 +6,3 @@
   - type: SpeechTransformable
   - type: RadioTransmittable
   - type: Audible
-  - type: WhisperMuffle
-    muffle: true

--- a/Resources/Prototypes/_DEN/Language/default.yml
+++ b/Resources/Prototypes/_DEN/Language/default.yml
@@ -6,5 +6,3 @@
   - type: SpeechTransformable
   - type: RadioTransmittable
   - type: Audible
-  - type: WhisperMuffle
-    muffle: true

--- a/Resources/Prototypes/_DEN/Language/sign.yml
+++ b/Resources/Prototypes/_DEN/Language/sign.yml
@@ -15,8 +15,6 @@
   components:
   - type: LineOfSightLanguage
   - type: VisualName
-  - type: WhisperMuffle
-    muffle: true
   - type: SyllableScrambling
     syllables:
     - "--"


### PR DESCRIPTION
## About the PR
Made whispers more private. They don't muffle anymore they just cut off at max range, they also require interaction range so they don't accidentally go through walls.

## Why / Balance
This is how it works in prebase.

## Technical details
Just added an extra interaction check and observer check, also removed WhisperMuffleComponent from the protos since it isn't doing anything right now.

## Test plan
Whisper to a second client.
Put some sort 

## Media

https://github.com/user-attachments/assets/01bf6cbf-accd-4973-84c6-8706c69b4759


## Requirements
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it.
- [X] I have added media to this PR or it does not require an in-game showcase.

### Licensing
- [X] All code in this pull request can be licensed to MIT.
- [X] (OPTIONAL) I give permission to seeing this feature upstreamed to Macrocosm in the future.

## Breaking changes


## Changelog
:cl:
- tweak: Made whispers just cut off at max range and hidden from ghosts again.
