### PR TITLE
Handle inverted requirements correctly and update UI

### DIFF
--- a/Content.Client/_DEN/Lobby/UI/Traits/EntityTraitSelector.xaml.cs
+++ b/Content.Client/_DEN/Lobby/UI/Traits/EntityTraitSelector.xaml.cs
@@ -137,8 +137,18 @@ public sealed partial class EntityTraitSelector : BoxContainer
         return tooltipString;
     }
 
-    public void SetInvalid(bool invalid)
+    public void UpdateAppearance(bool invalid)
     {
-        SelectorCheckbox.Label.FontColorOverride = invalid ? Color.Red : null;
+        if (_trait is null)
+            return;
+        var valid = SharedPlayerRequirementManager.CheckRequirements(GetContext(), _trait.Requirements);
+        SelectorCheckbox.Disabled = !valid && !Preference;
+        Color? fontColor = null;
+        if (invalid)
+            fontColor = Color.Red;
+        else if (!valid)
+            fontColor = Color.Gray;
+        
+        SelectorCheckbox.Label.FontColorOverride = fontColor;
     }
 }

--- a/Content.Client/_DEN/Lobby/UI/Traits/TraitCategoryBox.xaml.cs
+++ b/Content.Client/_DEN/Lobby/UI/Traits/TraitCategoryBox.xaml.cs
@@ -72,7 +72,7 @@ public sealed partial class TraitCategoryBox : BoxContainer
 
             var tooManySelected = TotalCost > category.MaxTraitPoints;
             foreach (var selector in _selectors)
-                selector.SetInvalid(tooManySelected);
+                selector.UpdateAppearance(tooManySelected);
         }
         else
             CategoryMaxTraitLabel.Visible = false;

--- a/Content.Shared/_DEN/Requirements/Managers/SharedPlayerRequirementManager.cs
+++ b/Content.Shared/_DEN/Requirements/Managers/SharedPlayerRequirementManager.cs
@@ -63,9 +63,9 @@ public abstract partial class SharedPlayerRequirementManager : IPlayerRequiremen
 
         // Check the actual requirement, now.
         if (!requirement.CheckRequirement(context))
-            return false;
+            return requirement.Inverted;
 
-        return true;
+        return !requirement.Inverted;
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
Made it so that the Inverted setting in requirements applies to their CheckRequirements logic instead of just their reason text. Fixes #127 

Also updated the trait UI to grey out and disable traits your requirements don't match for.

## Why / Balance
Bugfix + UI Clarity

## Technical details
It's a bool. Changed SetInvalid to a more generic UpdateAppearance function that handles the different appearances now.

## Test plan
I used the traits from the blood PR to test this, but:
Try to select a trait you can't.
Select one you can.
Switch to a species that wouldn't be able to select that trait.
Verify that you can still **UN**select it.

## Media

https://github.com/user-attachments/assets/4833717d-be18-4a82-88e7-8259487611a1


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

### Licensing
<!--
    This is REQUIRED for any code submitted to The Den 2 repository.
    If this is a port, make sure to check the original repository's license!

    This code can be licensed to MIT if:
    1. You wrote it yourself, and you agree it can be MIT-licensed.
    2. The original pull request originates from an MIT-licensed codebase, such as Wizard's Den.
    3. The original code author submitted the code to a non-MIT (e.g. AGPLv3) codebase, but
       has given explicit permission to have their code re-licensed.

    If your code does not fit these cases, it probably can't be accepted!
    If you need help getting MIT licensing, please ask for help in our development channels.
-->
- [X] All code in this pull request can be licensed to MIT.

<!--
    Macrocosm is The Den 2's upstream repository. We may port features to Macrocosm if other
    servers that share the Macrocosm upstream are interested in the feature.
-->
- [X] (OPTIONAL) I give permission to seeing this feature upstreamed to Macrocosm in the future.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
